### PR TITLE
Add permission dependencies

### DIFF
--- a/app/Http/Controllers/PermissionController.php
+++ b/app/Http/Controllers/PermissionController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Permission;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Spatie\Permission\Models\Permission;
 
 class PermissionController extends Controller
 {

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Spatie\Permission\Models\Role;
 
 class RoleController extends Controller
 {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -10,7 +11,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
-use Spatie\Permission\Models\Role;
 
 class UserController extends Controller
 {

--- a/app/Http/Livewire/Groups/Edit.php
+++ b/app/Http/Livewire/Groups/Edit.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Livewire\Groups;
 
+use App\Models\Role;
 use Livewire\Component;
-use Spatie\Permission\Models\Role;
 
 class Edit extends Component
 {

--- a/app/Http/Livewire/Groups/Permissions/Edit.php
+++ b/app/Http/Livewire/Groups/Permissions/Edit.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Livewire\Groups\Permissions;
 
+use App\Models\Permission;
+use App\Models\Role;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 class Edit extends Component
 {

--- a/app/Http/Livewire/Role/Create.php
+++ b/app/Http/Livewire/Role/Create.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Livewire\Role;
 
+use App\Models\Role;
 use Livewire\Component;
 use Livewire\Redirector;
-use Spatie\Permission\Models\Role;
 
 class Create extends Component
 {
@@ -22,7 +22,7 @@ class Create extends Component
     }
 
     protected $rules = [
-        'role.name' => 'required|max:255|unique:\Spatie\Permission\Models\Role,name',
+        'role.name' => 'required|max:255|unique:\App\Models\Role,name',
         'role.description' => 'max:255',
     ];
 

--- a/app/Http/Livewire/Users/Roles/Edit.php
+++ b/app/Http/Livewire/Users/Roles/Edit.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Livewire\Users\Roles;
 
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
-use Spatie\Permission\Models\Role;
 
 class Edit extends Component
 {

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Spatie\Permission\Models\Permission as SpatiePermission;
+
+class Permission extends SpatiePermission
+{
+    /**
+     * The permissions granted by this permission.
+     */
+    public function grants(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'permission_grants_permission', 'main_permission_id', 'granted_permission_id');
+    }
+
+    /**
+     * The permissions that grant this permission.
+     */
+    public function granted_by(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'permission_grants_permission', 'granted_permission_id', 'main_permission_id');
+    }
+
+    /**
+     * Returns all the superpermissions that grant this permission, all the
+     * way to the leaves (the ones that aren't granted by any other
+     * permissions).
+     *
+     * @example
+     * Permissions A, B and C don't have dependencies. A and B are granted by
+     * D. B is granted by E. E and D are granted by F. B.flattened_up()
+     * returns [B, D, E, F], not necessarily in that order.
+     *
+     * @return array<Permission>
+     */
+    public function flattened_up(): array
+    {
+        if (count($this->granted_by) === 0) {
+            return [$this];
+        }
+
+        $permissions = [];
+
+        foreach ($this->granted_by as $granting_permission) {
+            $permissions = array_merge($permissions, $granting_permission->flattened_up());
+        }
+
+        array_push($permissions, $this);
+
+        return $permissions;
+    }
+
+    /**
+     * Returns all the subpermissions granted by this one, all the way to the
+     * leaves (the ones without any grants for other permissions).
+     *
+     * @example
+     * Permission A grants B and C. Permission B grants D. A.flattened_down()
+     * returns [A, B, C, D], not necessarily in that order.
+     *
+     * @return array<Permission>
+     */
+    public function flattened_down(): array
+    {
+        if (count($this->grants) === 0) {
+            return [$this];
+        }
+
+        $permissions = [];
+
+        foreach ($this->grants as $granted_permission) {
+            $permissions = array_merge($permissions, $granted_permission->flattened_down());
+        }
+
+        array_push($permissions, $this);
+
+        return $permissions;
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Models;
+
+use Spatie\Permission\Models\Role as SpatieRole;
+
+class Role extends SpatieRole
+{
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,6 +39,30 @@ class User extends Authenticatable implements MustVerifyEmail
         'email_verified_at' => 'datetime',
     ];
 
+    public function hasDirectPermission($permission): bool
+    {
+        $permission = $this->filterPermission($permission);
+
+        foreach ($this->permissions as $permission) {
+            if (collect($permission->flattened_up())->contains($permission->getKeyName(), $permission->getKey())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function hasPermissionViaRole(Permission $permission): bool
+    {
+        foreach ($permission->flattened_up() as $flat_permission) {
+            if ($this->hasRole($flat_permission->roles)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function address(): BelongsTo
     {
         return $this->belongsTo(Address::class);

--- a/config/permission.php
+++ b/config/permission.php
@@ -13,7 +13,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => App\Models\Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -24,7 +24,7 @@ return [
          * `Spatie\Permission\Contracts\Role` contract.
          */
 
-        'role' => Spatie\Permission\Models\Role::class,
+        'role' => App\Models\Role::class,
 
     ],
 

--- a/database/migrations/2023_04_15_202710_create_table_permission_grants_permission.php
+++ b/database/migrations/2023_04_15_202710_create_table_permission_grants_permission.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permission_grants_permission', function (Blueprint $table) {
+            $table->primary(['main_permission_id', 'granted_permission_id']);
+            $table->foreignId('main_permission_id')->constrained('permissions');
+            $table->foreignId('granted_permission_id')->constrained('permissions');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::drop('permission_grants_permission');
+    }
+};

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -1,0 +1,32 @@
+# Authorization
+
+## How It Works
+
+The authorization has three important concepts: users, roles and permissions.
+Users are the same users that are used for authentication, represented by the
+`User` model. Roles group users together according to similarity in permissions.
+For example, all IT users may be added to a group `it_users`. Permissions are
+the most important part of the authorization logic. Permissions can be assigned
+to users and roles. An example permission might be `view_all_users`. A user with
+this permission or in a group with this permission can view all the users.
+
+Permissions can also grant extra permissions. It solves the problem of having to
+define every permission explicitly. For example if some functionality requires
+`view_basic_server_info`, but a user has the `view_detailed_server_info`
+permission, as long as the last one grants the first one, they will also be able
+to access the functionality.
+
+**Users should never directly get permissions**, as it doesn't scale well.
+Always assign permissions to roles, and roles to users.
+
+## Defining a New Permission/Role
+
+New permissions/starter roles can be defined in
+`App\Providers\AppServiceProvider` under `bootstrap_database`. **Don't forget to
+run the Artisan `bootstrap` command** to add everything to the database.
+
+## Extra Information
+
+-   [How to use the authorization
+    functionality](https://spatie.be/docs/laravel-permission/v5/basic-usage/basic-usage)
+-   [Laravel gates](https://laravel.com/docs/10.x/authorization#gates)

--- a/resources/views/control-panel/groups.blade.php
+++ b/resources/views/control-panel/groups.blade.php
@@ -11,7 +11,7 @@
           <th>{{ __('Name') }}</th>
           <th>{{ __('Description') }}</th>
         </tr>
-        @foreach (\Spatie\Permission\Models\Role::all() as $role)
+        @foreach (\App\Models\Role::all() as $role)
           <tr>
             <td>{{ $role->name }}</td>
             <td>{{ $role->description }}</td>

--- a/resources/views/control-panel/groups/edit.blade.php
+++ b/resources/views/control-panel/groups/edit.blade.php
@@ -13,7 +13,7 @@
       @livewire('groups.edit', ['role_id' => $group])
     </div>
     <div class="my-5">
-      @livewire('groups.permissions.edit', ['role' => \Spatie\Permission\Models\Role::findOrFail($group)])
+      @livewire('groups.permissions.edit', ['role' => \App\Models\Role::findOrFail($group)])
     </div>
   </x-control-panel-layout>
 </x-app-layout>

--- a/resources/views/control-panel/permissions.blade.php
+++ b/resources/views/control-panel/permissions.blade.php
@@ -12,7 +12,7 @@
           <th>{{ __('Name') }}</th>
           <th>{{ __('Description') }}</th>
         </tr>
-        @foreach (\Spatie\Permission\Models\Permission::all() as $permission)
+        @foreach (App\Models\Permission::all() as $permission)
           <tr>
             <td>{{ $permission->name }}</td>
             <td>{{ $permission->description }}</td>


### PR DESCRIPTION
Permission dependencies allow aliasing dependencies under one common name. This is useful when describing a group of general functionality while not having to care about the specific dependencies, which can change without affecting the behavior of the group/alias.